### PR TITLE
Buildroot 2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ buildroot/buildroot-2016.11.1-*
 buildroot/download
 buildroot/host
 images/
+*.swp

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -4,10 +4,12 @@ RUN dnf install -y make gcc gcc-c++ automake m4 autoconf git wget bzip2 which un
     python elfutils-libelf-devel
 
 RUN mkdir -p /build/buildroot
+RUN mkdir -p /build/.git
 
 ARG USER=0
 ARG GROUP=0
 COPY --chown=$USER:$GROUP buildroot/ /build/buildroot/
+COPY --chown=$USER:$GROUP .git/ /build/.git/
 
 # Big hack: make 4.3 introduced a serious regression that renders buildroot inoperable. Let's build make 4.4 to work around this.
 RUN cd /build/; \

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM rockylinux:9
 
 RUN dnf install -y make gcc gcc-c++ automake m4 autoconf git wget bzip2 which unzip file diffutils binutils patch gzip perl cpio rsync bc findutils \
     python elfutils-libelf-devel
@@ -20,7 +20,7 @@ RUN cd /build/; \
 	cd .. && rm -rf ./make-4.4.1 && rm make-4.4.1.tar.gz;
 
 # Build the requested target arch and copy to the final location
-ARG BUILDROOT_VERSION=2019.08
+ARG BUILDROOT_VERSION=2025.02
 ARG BUILDROOT_ARCH=x86_64
 ARG TOOLCHAIN_ONLY=0
 RUN PATH="/build/host/bin:$PATH" && /build/buildroot/setup.sh -v ${BUILDROOT_VERSION} -a ${BUILDROOT_ARCH} --toolchain-only ${TOOLCHAIN_ONLY}; \

--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -3,11 +3,11 @@ FROM rockylinux:9
 RUN dnf install -y make gcc gcc-c++ automake m4 autoconf git wget bzip2 which unzip file diffutils binutils patch gzip perl cpio rsync bc findutils \
     python elfutils-libelf-devel
 
-RUN mkdir -p /build
+RUN mkdir -p /build/buildroot
 
 ARG USER=0
 ARG GROUP=0
-COPY --chown=$USER:$GROUP . /build/
+COPY --chown=$USER:$GROUP buildroot/ /build/buildroot/
 
 # Big hack: make 4.3 introduced a serious regression that renders buildroot inoperable. Let's build make 4.4 to work around this.
 RUN cd /build/; \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,10 +4,12 @@ RUN dnf install -y make gcc gcc-c++ automake m4 autoconf git wget bzip2 which un
     python elfutils-libelf-devel
 
 RUN mkdir -p /build/buildroot
+RUN mkdir -p /build/.git
 
 ARG USER=0
 ARG GROUP=0
 COPY --chown=$USER:$GROUP buildroot/ /build/buildroot/
+COPY --chown=$USER:$GROUP .git/ /build/.git/
 
 # Big hack: make 4.3 introduced a serious regression that renders buildroot inoperable. Let's build make 4.4 to work around this.
 RUN cd /build/; \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM rockylinux:9
 
 RUN dnf install -y make gcc gcc-c++ automake m4 autoconf git wget bzip2 which unzip file diffutils binutils patch gzip perl cpio rsync bc findutils \
     python elfutils-libelf-devel

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,11 +3,11 @@ FROM rockylinux:9
 RUN dnf install -y make gcc gcc-c++ automake m4 autoconf git wget bzip2 which unzip file diffutils binutils patch gzip perl cpio rsync bc findutils \
     python elfutils-libelf-devel
 
-RUN mkdir -p /build
+RUN mkdir -p /build/buildroot
 
 ARG USER=0
 ARG GROUP=0
-COPY --chown=$USER:$GROUP . /build/
+COPY --chown=$USER:$GROUP buildroot/ /build/buildroot/
 
 # Big hack: make 4.3 introduced a serious regression that renders buildroot inoperable. Let's build make 4.4 to work around this.
 RUN cd /build/; \

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024, The Board of Trustees of the Leland Stanford Junior 
+Copyright (c) 2025, The Board of Trustees of the Leland Stanford Junior 
 University, through SLAC National Accelerator Laboratory (subject to receipt 
 of any required approvals from the U.S. Dept. of Energy). All rights reserved. 
 Redistribution and use in source and binary forms, with or without 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,15 @@ First, create the container (i.e. for i686):
 
 After the build is complete, use `get-images.sh` to extract the images from the container:
 ```
-./get-images.sh -t 2019.08 -t 2019.08-i686
+./get-images.sh -t 2025.02 -t 2025.02-i686
 ```
 
-The resulting images will be in `images/buildroot-2019.08-i686`.
+The resulting images will be in `images/buildroot-2025.02-i686`.
 
 ### Development
 
 `Dockerfile.dev` defines a development container that can be used to compile the buildroot images for iterative development. 
-Due to the age of these images, they generally will not compile on modern Linux distros, but they will build in this container (which is based on Fedora 30). 
-They should also build fine on Rocky 9/RHEL9.
+Due to the age of these images, they generally will not compile on modern Linux distros, but they will build in this container (which is based on Rocky 9).
 
 To bootstrap a development container, run `./start-dev-container.sh`. 
 This will build the docker image and launch the container under the name slac-buildroot-dev-container. 
@@ -61,10 +60,10 @@ To run commands in this container, run `./run-docker-cmd.sh mycommand and stuff`
 Example:
 ```sh
 # Bootstrap buildroot; download the tarball, apply patches and build
-./run-docker-cmd.sh ./buildroot/setup.sh -v 2019.08 -a i686
+./run-docker-cmd.sh ./buildroot/setup.sh -v 2025.02 -a i686
 
 # After that, you can run make directly to rebuild the container as you need
-./run-docker-cmd.sh make -C buildroot/buildroot-2019.08-i686
+./run-docker-cmd.sh make -C buildroot/buildroot-2025.02-i686
 ```
 
 ## Using the Containerized Toolchains
@@ -73,7 +72,7 @@ The buildroot paths within the container match what's found on S3DF. Thus, most 
 
 The top of the buildroot directory is located at `/sdf/sw/epics/package/linuxRT/buildroot-<version>`
 
-For buildroot-2019.08 and x86_64, GCC would be at: `/sdf/sw/epics/package/linuxRT/buildroot-2019.08/host/linux-x86_64/x86_64/bin/x86_64-buildroot-linux-gnu-gcc`
+For buildroot-2025.02 and x86_64, GCC would be at: `/sdf/sw/epics/package/linuxRT/buildroot-2025.02/host/linux-x86_64/x86_64/bin/x86_64-buildroot-linux-gnu-gcc`
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ First, create the container (i.e. for i686):
 
 After the build is complete, use `get-images.sh` to extract the images from the container:
 ```
-./get-images.sh -t 2025.02 -t 2025.02-i686
+./get-images.sh -v 2025.02 -t 2025.02-i686
 ```
 
 The resulting images will be in `images/buildroot-2025.02-i686`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,25 @@
 
 This repository contains dockerized build infrastructure for SLAC's buildroot images and their associated toolchains.
 
-## Pulling Pre-built Containers
+## Building the Toolchain and Disk Image
+
+To build the images locally from scratch, follow this guide.
+
+First, create the container (i.e. for i686):
+```
+./create-container.sh -a i686
+```
+
+After the build is complete, use `get-images.sh` to extract the images from the container:
+```
+./get-images.sh -t 2025.02 -t 2025.02-i686
+```
+
+The resulting images will be in `images/buildroot-2025.02-i686`.
+
+For other target architectures/systems, swap i686 for x86_64 or zynq.
+
+## Pre-built Containers
 
 Prebuilt containers can be obtained from GitHub's package registry as follows:
 
@@ -28,22 +46,6 @@ For example, to extract buildroot-2019.08 x86_64 image from the pre-built contai
 ```sh
 ./get-images.sh -r -v 2019.08 -t 2019.08-x86_64
 ```
-
-## Building
-
-To build the images locally from scratch, follow this guide.
-
-First, create the container (i.e. for i686):
-```
-./create-container.sh -a i686
-```
-
-After the build is complete, use `get-images.sh` to extract the images from the container:
-```
-./get-images.sh -v 2025.02 -t 2025.02-i686
-```
-
-The resulting images will be in `images/buildroot-2025.02-i686`.
 
 ### Development
 

--- a/buildroot/setup.sh
+++ b/buildroot/setup.sh
@@ -124,10 +124,10 @@ ulimit -n 8192 || true
 
 if [ "$TOOLCHAIN" == "1" ]; then
 	# Build the toolchain *only*. That's what we care about :)
-	make toolchain -j$(nproc)
+	make toolchain
 else
 	# Build everything
-	make -j$(nproc)
+	make
 fi
 
 popd > /dev/null

--- a/buildroot/setup.sh
+++ b/buildroot/setup.sh
@@ -6,14 +6,14 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 function usage {
     echo "USAGE: setup.sh -v VERSION -a ARCH [--git REPO] [-b BRANCH] [--download-only]"
-	echo "  -v <version>      - Version to build (i.e. 2019.08)"
+	echo "  -v <version>      - Version to build (i.e. 2025.02)"
 	echo "  -a <arch>         - Arch to build for (i686, x86_64, zynq)"
 	echo "  --download-only   - Only download and do basic setup, don't build"
 	echo "  --git <repo>      - Clone GIT repository instead"
 	echo "  -b <branch>       - If cloning a git repo, checkout this ref after the fact"
 	echo "Examples:"
-	echo "  $0 -v 2019.08 -a x86_64"
-	echo "  $0 -v 2019.08 -a i686"
+	echo "  $0 -v 2025.02 -a x86_64"
+	echo "  $0 -v 2025.02 -a i686"
     exit 1
 }
 
@@ -64,6 +64,9 @@ if [ "$ARCH" != "zynq" ] && [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; th
 fi
 
 case $VERSION in
+    2025.02)
+        FILE="buildroot-2025.02"
+        ;;
     2019.08)
         FILE="buildroot-2019.08.1"
         ;;
@@ -78,14 +81,14 @@ esac
 DIR="buildroot-$VERSION-$ARCH"
 
 mkdir -p download
-if [ ! -f download/$FILE.tar.bz2 ] && [ -z $REPO ]; then
-    wget -O "download/$FILE.tar.bz2" "https://buildroot.org/downloads/$FILE.tar.bz2"
+if [ ! -f download/$FILE.tar.gz ] && [ -z $REPO ]; then
+    wget -O "download/$FILE.tar.gz" "https://buildroot.org/downloads/$FILE.tar.gz"
 fi
 
 # Extract our tarball or clone our GIT repo
 if [ ! -d "$DIR" ]; then
 	if [ -z $REPO ]; then
-	    tar -xf "download/$FILE.tar.bz2"
+	    tar -xf "download/$FILE.tar.gz"
     	mv "$FILE" "$DIR"
 	else
 		git clone -b "$REF" "$REPO" "$DIR" 

--- a/create-container.sh
+++ b/create-container.sh
@@ -2,7 +2,7 @@
 set -e
 
 ARCHES="x86_64 i686 arm"
-VER="2019.08"
+VER="2025.02"
 
 while test $# -gt 0; do
     case $1 in
@@ -19,8 +19,8 @@ while test $# -gt 0; do
             echo "  -v version       : buildroot version"
             echo "  -a arch          : Target arch (i686, arm, x86_64)"
             echo "Examples:"
-            echo "  $0 -v 2019.08 -a x86_64"
-            echo "  $0 -v 2019.08 -a x86_64 -a i686"
+            echo "  $0 -v 2025.02 -a x86_64"
+            echo "  $0 -v 2025.02 -a x86_64 -a i686"
             exit 0
             ;;
         *)

--- a/get-images.sh
+++ b/get-images.sh
@@ -4,8 +4,8 @@ TOP="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 
 function usage {
     echo "USAGE: $0 -v version -t tag [-r|--remote]"
-    echo "  -v version           : The buildroot version (i.e. 2019.08)"
-    echo "  -t tag               : The docker image tag (i.e. 2019.08-x86_64)"
+    echo "  -v version           : The buildroot version (i.e. 2025.02)"
+    echo "  -t tag               : The docker image tag (i.e. 2025.02-x86_64)"
     echo "  -r --remote          : Use remote docker container"
     exit 1
 }

--- a/get-tarball.sh
+++ b/get-tarball.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+function usage {
+    echo "USAGE: $0 -v version -t tag [-r|--remote]"
+    echo "  -v version           : The buildroot version (i.e. 2025.02)"
+    echo "  -t tag               : The docker image tag (i.e. 2025.02-x86_64)"
+    echo "  -r --remote          : Use remote docker container"
+    exit 1
+}
+
 IMAGE=slac-buildroot
 for a in $@; do
 	case $a in
@@ -15,14 +23,16 @@ for a in $@; do
 		TAG="$2"
 		shift 2
 		;;
+    -h|--help)
+		usage
+        ;;
 	*)
 		;;
 	esac
 done
 
 if [ -z "$TAG" ] || [ -z "$VER" ]; then
-	echo "-t and -v are required"
-	exit 1
+	usage
 fi
 
 docker run --rm -v "$PWD":"$PWD" -w "/sdf/sw/epics/package/linuxRT" "$IMAGE:$TAG" bash -c "tar -cf \"$PWD/buildroot-$TAG.tgz\" buildroot-$VER"

--- a/scripts/run-qemu-x86_64.sh
+++ b/scripts/run-qemu-x86_64.sh
@@ -1,5 +1,29 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "${BASH_SOURCE}")/../buildroot/buildroot-2019.08-x86_64/output/images"
+function usage {
+    echo "USAGE: $0 -v version "
+    echo "  -v version           : The buildroot version (i.e. 2025.02)"
+    exit 1
+}
+
+for a in $@; do
+	case $a in
+	-v)
+		VER="$2"
+		shift 2
+		;;
+    -h|--help)
+		usage
+        ;;
+	*)
+		;;
+	esac
+done
+
+if [ -z "$VER" ]; then
+	usage
+fi
+
+cd "$(dirname "${BASH_SOURCE}")/../buildroot/buildroot-$VER-x86_64/output/images"
 qemu-system-x86_64 -m size=2048 -no-reboot -nographic -kernel ./bzImage -initrd ./rootfs.ext2 -append "console=ttyS0 init=/linuxrc root=/dev/ram0" \
 	-nic user,hostfwd=tcp::8022-:22


### PR DESCRIPTION
- Changed container base from Fedora 30 to Rocky 9.
- Added .git to the container so the script post-build can update the information from Git to add the tag to /etc/os-release.
- Modified README and help from all scripts to default to Buildroot 2025.02.
- Added an argument checker and a help function to get-tarball.sh and run-qemu-x86_64.sh.
- Updated the sub-module reference to use the Buildroot 2025 branch.